### PR TITLE
Fix extra bracket, was causing error

### DIFF
--- a/_sass-list-maps.scss
+++ b/_sass-list-maps.scss
@@ -271,7 +271,7 @@
     $index: index($keys1, tuple-key($tuple));
 
     @if $index { $list1: set-nth($list1, $index, $tuple); }
-    @else { $list1: append($list1, $tuple, 'comma'); } }
+    @else { $list1: append($list1, $tuple, 'comma'); }
   }
 
   @return $list1;


### PR DESCRIPTION
Caused:

```
sass-list-maps:278: error: invalid top-level expression
```
